### PR TITLE
Improved performance with FORTRAN90

### DIFF
--- a/rmnest/COMPILE_FORT
+++ b/rmnest/COMPILE_FORT
@@ -1,0 +1,6 @@
+f2py -c circular.f90 -lm -m circular -DF2PY_REPORT_ON_ARRAY_COPY=1 --f90flags='-fcheck=bounds -frepack-arrays -C' 
+#--fcompiler=gfortran
+
+#f2py -c Dedis.f90 -lfftw3 -lm -m incoherent_dedisp -DF2PY_REPORT_ON_ARRAY_COPY=1 --f90flags='-fcheck=bounds -frepack-arrays -C' 
+#--fcompiler=gfortran
+

--- a/rmnest/circular.f90
+++ b/rmnest/circular.f90
@@ -19,7 +19,6 @@ subroutine circular(frequency,&
         integer(kind=4):: i,j
 
         !Defining constants
-        
         real(kind=8):: const_c
         real(kind=8):: const_mega
         real(kind=8):: deg2rad
@@ -34,11 +33,11 @@ subroutine circular(frequency,&
         real(kind=8), intent(in):: theta
         
         real(kind=8), intent(in), dimension(len_ch)       ::frequency
-        real(kind=8),  dimension(len_ch)       ::psi
+        real(kind=8),  dimension(len_ch)                  ::psi
 
-        real(kind=8),  dimension(len_ch, 3)       ::stokesp
-        real(kind=8),  dimension(3, 3)            ::rot_kernel
-        real(kind=8), intent(out), dimension(len_ch, 3)         ::rot_vector
+        real(kind=8),  dimension(len_ch, 3)               ::stokesp
+        real(kind=8),  dimension(3, 3)                    ::rot_kernel
+        real(kind=8), intent(out), dimension(len_ch, 3)   ::rot_vector
         
         const_c     =   299792458
         const_mega  =   1000000
@@ -52,15 +51,7 @@ subroutine circular(frequency,&
                 stokesp(i,2)   =   sin(2*psi(i))*cos(2*chi*deg2rad)
                 stokesp(i,3)   =   sin(2*chi*deg2rad) 
         end do
-        
-        !do i=1, 3 
-        !    do j=1, len_ch
-        !        sq(i)(j)   =   cos(2*psi(i))*cos(2*chi*deg2rad)
-        !        su(i)(j)   =   sin(2*psi(i))*cos(2*chi*deg2rad)
-        !        sv(i)(j)   =   sin(2*chi*deg2rad) 
-        !    end do
-        !end do
-        
+       
         !defining manualy :')
         rot_kernel(1,1)    =   cos(theta*deg2rad)*cos(phi*deg2rad)
         rot_kernel(1,2)    =  -cos(theta*deg2rad)*sin(phi*deg2rad)
@@ -71,11 +62,7 @@ subroutine circular(frequency,&
         rot_kernel(3,1)    =   -sin(theta*deg2rad)*cos(phi*deg2rad)
         rot_kernel(3,2)    =   sin(theta*deg2rad)*sin(phi*deg2rad)
         rot_kernel(3,3)    =   cos(theta*deg2rad)
-        
-        !mat_thea = array([[cos(theta)*cos(phi), -cos(theta)*sin(phi), sin(theta)],
-        ![sin(phi), cos(phi), 0], [-sin(theta)*cos(phi), sin(theta)*sin(phi),
-        !cos(theta)]]) 
-        
+       
         rot_vector          =   matmul(stokesp, rot_kernel)
 
         end subroutine circular

--- a/rmnest/circular.f90
+++ b/rmnest/circular.f90
@@ -1,0 +1,82 @@
+
+
+subroutine circular(frequency,&
+                    frequency_cen,&
+                    len_ch,&
+                    psi_0,&
+                    grm,&
+                    alpha,&
+                    chi,&
+                    phi,&
+                    theta,&
+                    rot_vector)
+        
+        implicit none
+
+        !f2py threadsafe
+        integer(kind=4), intent(in):: len_ch
+                
+        integer(kind=4):: i,j
+
+        !Defining constants
+        
+        real(kind=8):: const_c
+        real(kind=8):: const_mega
+        real(kind=8):: deg2rad
+        
+
+        real(kind=8), intent(in):: frequency_cen
+        real(kind=8), intent(in):: alpha
+        real(kind=8), intent(in):: chi
+        real(kind=8), intent(in):: phi
+        real(kind=8), intent(in):: grm
+        real(kind=8), intent(in):: psi_0
+        real(kind=8), intent(in):: theta
+        
+        real(kind=8), intent(in), dimension(len_ch)       ::frequency
+        real(kind=8),  dimension(len_ch)       ::psi
+
+        real(kind=8),  dimension(len_ch, 3)       ::stokesp
+        real(kind=8),  dimension(3, 3)            ::rot_kernel
+        real(kind=8), intent(out), dimension(len_ch, 3)         ::rot_vector
+        
+        const_c     =   299792458
+        const_mega  =   1000000
+
+        do i=1, len_ch
+                psi(i)  =   psi_0*deg2rad + grm * (&
+                             ((const_c/(frequency(i) * const_mega))**alpha)&
+                             -((const_c/(frequency_cen * const_mega))**alpha))
+
+                stokesp(i,1)   =   cos(2*psi(i))*cos(2*chi*deg2rad)
+                stokesp(i,2)   =   sin(2*psi(i))*cos(2*chi*deg2rad)
+                stokesp(i,3)   =   sin(2*chi*deg2rad) 
+        end do
+        
+        !do i=1, 3 
+        !    do j=1, len_ch
+        !        sq(i)(j)   =   cos(2*psi(i))*cos(2*chi*deg2rad)
+        !        su(i)(j)   =   sin(2*psi(i))*cos(2*chi*deg2rad)
+        !        sv(i)(j)   =   sin(2*chi*deg2rad) 
+        !    end do
+        !end do
+        
+        !defining manualy :')
+        rot_kernel(1,1)    =   cos(theta*deg2rad)*cos(phi*deg2rad)
+        rot_kernel(1,2)    =  -cos(theta*deg2rad)*sin(phi*deg2rad)
+        rot_kernel(1,3)    =   sin(theta*deg2rad)
+        rot_kernel(2,1)    =   sin(phi*deg2rad)
+        rot_kernel(2,2)    =   cos(phi*deg2rad)
+        rot_kernel(2,3)    =      0 
+        rot_kernel(3,1)    =   -sin(theta*deg2rad)*cos(phi*deg2rad)
+        rot_kernel(3,2)    =   sin(theta*deg2rad)*sin(phi*deg2rad)
+        rot_kernel(3,3)    =   cos(theta*deg2rad)
+        
+        !mat_thea = array([[cos(theta)*cos(phi), -cos(theta)*sin(phi), sin(theta)],
+        ![sin(phi), cos(phi), 0], [-sin(theta)*cos(phi), sin(theta)*sin(phi),
+        !cos(theta)]]) 
+        
+        rot_vector          =   matmul(stokesp, rot_kernel)
+
+        end subroutine circular
+

--- a/rmnest/likelihood.py
+++ b/rmnest/likelihood.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 import numpy as np
 import bilby
 from uncertainties import unumpy
-from rmnest.model import GeneralisedFaradayRotation
-
+#from rmnest.model import GeneralisedFaradayRotation
+import circular
 
 class FRLikelihood(bilby.likelihood.Likelihood):
     """
@@ -192,20 +192,45 @@ class GFRLikelihood(bilby.likelihood.Likelihood):
         return np.sqrt(self.norm_s_v_rms**2 + self.parameters["sigma"] ** 2)
 
     def log_likelihood(self):
-        gfr_model = GeneralisedFaradayRotation(
-            self.freq,
-            self.freq_cen,
-            self.parameters["psi_zero"],
-            self.parameters["grm"],
-            alpha=self.parameters["alpha"],
-            chi=self.parameters["chi"],
-            phi=self.parameters["phi"],
-            theta=self.parameters["theta"],
-        )
+        gfr_model   =   circular.circular(
+                                            self.freq,
+                                            self.freq_cen,
+                                            self.parameters["psi_zero"],
+                                            self.parameters["grm"],
+                                            self.parameters["alpha"],
+                                            self.parameters["chi"],
+                                            self.parameters["phi"],
+                                            self.parameters["theta"],
+                                         )
+        
+        
+        '''
+        frequency : input rank-1 array('d') with bounds (len_ch)
+        frequency_cen : input float
+        psi_0 : input float
+        grm : input float
+        alpha : input float
+        chi : input float
+        phi : input float
+        theta : input float
+        '''
+        
+        
+        
+        #gfr_model = GeneralisedFaradayRotation(
+        #    self.freq,
+        #    self.freq_cen,
+        #    self.parameters["psi_zero"],
+        #    self.parameters["grm"],
+        #    alpha=self.parameters["alpha"],
+        #    chi=self.parameters["chi"],
+        #    phi=self.parameters["phi"],
+        #    theta=self.parameters["theta"],
+        #)
 
-        residual_q = (self.norm_s_q - gfr_model.m_q) / self.norm_s_q_sigma
-        residual_u = (self.norm_s_u - gfr_model.m_u) / self.norm_s_u_sigma
-        residual_v = (self.norm_s_v - gfr_model.m_v) / self.norm_s_v_sigma
+        residual_q = (self.norm_s_q - gfr_model[:,0]) / self.norm_s_q_sigma
+        residual_u = (self.norm_s_u - gfr_model[:,1]) / self.norm_s_u_sigma
+        residual_v = (self.norm_s_v - gfr_model[:,2]) / self.norm_s_v_sigma
         ln_l_q = np.sum(residual_q**2 + np.log(2 * np.pi * self.norm_s_q_sigma**2))
         ln_l_u = np.sum(residual_u**2 + np.log(2 * np.pi * self.norm_s_u_sigma**2))
         ln_l_v = np.sum(residual_v**2 + np.log(2 * np.pi * self.norm_s_v_sigma**2))


### PR DESCRIPTION
The current implementation uses scipy based functions for the matrix multiplication in circular polarisation model calculations. Although, scipy implementation is robust and well tested, it has lot of overheads associated with it, hence increasing the complexity of the GFR modelling function.

This alternate implementation is faster due to the implementation of GFR model in fortran90. Currently only GFR has been implemented in fortran. Additional conversion of likelihood function to fortran can further speed up the process. 